### PR TITLE
client.events = 0;

### DIFF
--- a/handlers/bot/event.js
+++ b/handlers/bot/event.js
@@ -1,8 +1,5 @@
 const {readdirSync} = require('fs');
-const colors = require('colors');
-let a = 0;
-let e = 0;
-
+const e = 0;
 module.exports = (client) => {
     console.log(`=-=-=-=-=-=-=-=-= WELCOME TO ADVANCED EVENTS HANDLER =-=-=-=-=-=-=-=-=`.green)
     readdirSync("./Events/").forEach(dir => {
@@ -13,7 +10,7 @@ module.exports = (client) => {
                 client.events.set(pull.name, pull);
                 e++
             } else {
-                a++
+                client.events++
                 continue;
             }
         }

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ client.commands = new Collection();
 client.aliases = new Collection();
 client.categories = fs.readdirSync("./Commands/");
 client.context = new Collection();
-client.events = new Collection();
+client.events = 0;
 
 //connecting handlers
 ["command", "event","slash"].forEach(handler => {


### PR DESCRIPTION
There is no need to create a collection for `client.events` as we are just requiring the event file.
We can do 
```
client.events = 0;
```
and then in case of a file we can do `client.events++`.
Hope this helps! @Elitex07 